### PR TITLE
Disable mutex if mutex does not exists

### DIFF
--- a/mrblib/instance_storage.rb
+++ b/mrblib/instance_storage.rb
@@ -9,6 +9,14 @@ module InstanceStorage
 
   alias to_sym name
 
+  unless const_defined?(:Mutex)
+    class Mutex
+      def synchronize
+        yield
+      end
+    end
+  end
+
   def self.included(klass)
     super
     klass.class_eval do


### PR DESCRIPTION
mrubyの場合は、マルチスレッド動作することはないのでCRubyと違ってスレッドセーフである必要はないと思います。
かといって、thread gemがあるので全く不可能というわけでもなく、その場合はこのinstance-storageはthread unsafeになってしまいます。
そもそもlock機構を削除してもいいと思うんですが、よしなに処理を分岐するコードを書いてみました
